### PR TITLE
Fix CMake file linker path for s130 target

### DIFF
--- a/bbc-microbit-classic-gcc-s130/CMake/toolchain.cmake
+++ b/bbc-microbit-classic-gcc-s130/CMake/toolchain.cmake
@@ -19,7 +19,7 @@ set(CMAKE_C_FLAGS_INIT             "${CMAKE_C_FLAGS_INIT} ${_CPU_COMPILATION_OPT
 set(CMAKE_ASM_FLAGS_INIT           "${CMAKE_ASM_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
 set(CMAKE_CXX_FLAGS_INIT           "${CMAKE_CXX_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS} -std=c++11 -fwrapv")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_MODULE_LINKER_FLAGS_INIT} -mcpu=cortex-m0 -mthumb")
-set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -mcpu=cortex-m0 -mthumb -T\"${CMAKE_CURRENT_LIST_DIR}/../ld/NRF51822.ld\"")
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -mcpu=cortex-m0 -mthumb -T\"${CMAKE_CURRENT_LIST_DIR}/../ld/NRF51822_S130.ld\"")
 
 # used by the apply_target_rules function below:
 set(NRF51822_SOFTDEVICE_HEX_FILE "${CMAKE_CURRENT_LIST_DIR}/../softdevice/s130_nrf51_1.0.0_softdevice.hex")


### PR DESCRIPTION
Fixes #4.

As indicated in https://github.com/lancaster-university/microbit-targets/issues/4 the linker path is not correct.
Looking at the git history this issue was introduced accidentally in 09cf98ea0c05a5be49435cc6ad15727caeeaee62.

If everything is well it'd be good enough to merge this PR, no need to push to the yotta registry as it has been deprecated (yotta dependencies/targets can still point to git urls, so we should start moving all the microbit yotta config files to that). 